### PR TITLE
[sonar] Split test into test-type specific profiles

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     stage('Package & test Capella Studio') {
       steps {
       	wrap([$class: 'Xvnc', takeScreenshot: false, useXauthority: true]) {
-        	sh 'mvn  -Dmaven.test.failure.ignore=true -Dtycho.localArtifacts=ignore clean verify -P full -P sign -P product -e -f pom.xml'
+        	sh 'mvn  -Dmaven.test.failure.ignore=true -Dtycho.localArtifacts=ignore clean verify -P full -P sign -P product -P ju_tests -P rcptt_tests -e -f pom.xml'
         }
       }
     }

--- a/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.ju/.project
+++ b/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.ju/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.polarsys.capella.studio.releng.aggregator.tests</name>
+	<name>org.polarsys.capella.studio.releng.aggregator.tests.ju</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.ju/pom.xml
+++ b/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.ju/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (c) 2006, 2020 THALES GLOBAL SERVICES.
+  Copyright (c) 2020 THALES GLOBAL SERVICES.
   This program and the accompanying materials are made available under the
   terms of the Eclipse Public License 2.0 which is available at
   http://www.eclipse.org/legal/epl-2.0
@@ -16,10 +16,10 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.polarsys.capella</groupId>
-  <artifactId>org.polarsys.capella.studio.releng.aggregator.tests</artifactId>
+  <artifactId>org.polarsys.capella.studio.releng.aggregator.tests.ju</artifactId>
   <packaging>pom</packaging>
 
-  <name>Capella Sudio tests Aggregator Module </name>
+  <name>Capella Sudio JU tests Aggregator Module</name>
 
   <parent>
     <groupId>org.polarsys.capella</groupId>
@@ -46,16 +46,9 @@
     <module>../../../tests/plugins/org.polarsys.capella.studio.test</module>
     <module>../../../extension/tests/org.polarsys.capella.extension.rcptt</module>
     <module>../../../vpdsl/tests/org.polarsys.capella.ad.viewpoint.dsl.tests</module>
-    <!-- Plugin Tests RCPTT Capella Studio -->
-    <!-- module>../../../gendoc/tests/org.polarsys.capella.gen.doc.tests</module-->
-    <module>../../../vpdsl/tests/org.polarsys.capella.studio.ad.viewpoint.rcptt</module>
-    <module>../../../vpdsl/tests/capellastudio.vpdsl.qualityassessment.reverse.tests</module>
-    <module>../../../vpdsl/tests/capellastudio.vpdsl.qualityassessment.tests</module>
-    
     
     <!-- Features  -->
     <module>../../../tests/features/org.polarsys.capella.studio.test.feature</module>
-    
   </modules>
 </project>
 

--- a/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.rcptt/.project
+++ b/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.rcptt/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.polarsys.capella.studio.releng.aggregator.tests.rcptt</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.rcptt/pom.xml
+++ b/releng/plugins/org.polarsys.capella.studio.releng.aggregator.tests.rcptt/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Copyright (c) 2020 THALES GLOBAL SERVICES.
+  This program and the accompanying materials are made available under the
+  terms of the Eclipse Public License 2.0 which is available at
+  http://www.eclipse.org/legal/epl-2.0
+
+  SPDX-License-Identifier: EPL-2.0
+
+  Contributors:
+       Thales - initial API and implementation
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.polarsys.capella</groupId>
+  <artifactId>org.polarsys.capella.studio.releng.aggregator.tests.rcptt</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Capella Sudio RCPTT tests Aggregator Module</name>
+
+  <parent>
+    <groupId>org.polarsys.capella</groupId>
+    <artifactId>org.polarsys.capella.studio</artifactId>
+    <version>5.0.0-SNAPSHOT</version>
+    <relativePath>../org.polarsys.capella.studio.releng.parent</relativePath>
+  </parent>
+  
+  <licenses>
+    <license>
+      <name>Eclipse Public License v2.0</name>
+      <comments>
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License 2.0 which is available at
+      http://www.eclipse.org/legal/epl-2.0
+
+      SPDX-License-Identifier: EPL-2.0
+      </comments>
+    </license>
+  </licenses>
+
+  <modules>
+    <!-- Plugin Tests RCPTT Capella Studio -->
+    <!-- module>../../../gendoc/tests/org.polarsys.capella.gen.doc.tests</module-->
+    <module>../../../vpdsl/tests/org.polarsys.capella.studio.ad.viewpoint.rcptt</module>
+    <module>../../../vpdsl/tests/capellastudio.vpdsl.qualityassessment.reverse.tests</module>
+    <module>../../../vpdsl/tests/capellastudio.vpdsl.qualityassessment.tests</module>
+    
+    <!-- Features  -->
+    <module>../../../tests/features/org.polarsys.capella.studio.test.feature</module>   
+  </modules>
+</project>
+

--- a/releng/plugins/org.polarsys.capella.studio.releng.parent/pom.xml
+++ b/releng/plugins/org.polarsys.capella.studio.releng.parent/pom.xml
@@ -42,7 +42,6 @@
 	<properties>
 		<tycho-version>2.0.0</tycho-version>
 		<tycho-extras-version>2.0.0</tycho-extras-version>
-		<platform-version-name>oxygen</platform-version-name>
 		<tycho.scmUrl>scm:git:https://git.polarsys.org/r/kitalpha/kitalpha</tycho.scmUrl>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -50,8 +49,7 @@
 		<testFiltreClass>**/AllTests.java</testFiltreClass>
 		<coverage.skip>false</coverage.skip>
 		<coverage.destFile>./target/jacoco.exec</coverage.destFile>
-		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
-		<!-- <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis> -->
+		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
 		<sonar.jacoco.release>0.8.6</sonar.jacoco.release>
 		<rcptt-maven-version>2.4.3</rcptt-maven-version>
 		<capellastudio-product-id>org.polarsys.capella.studio.product.CapellaStudio</capellastudio-product-id>
@@ -143,9 +141,26 @@
 			</properties>
 			<modules>
 				<module>../../../releng/plugins/org.polarsys.capella.studio.releng.product</module>
-				<module>../org.polarsys.capella.studio.releng.aggregator.tests</module>
 				
 				<!--module>../../../releng/plugins/org.polarsys.capella.studio.releng.targets</module-->
+			</modules>
+		</profile>
+		<profile>
+			<id>ju_tests</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<modules>
+				<module>../org.polarsys.capella.studio.releng.aggregator.tests.ju</module>
+			</modules>
+		</profile>
+		<profile>
+			<id>rcptt_tests</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<modules>
+				<module>../org.polarsys.capella.studio.releng.aggregator.tests.rcptt</module>
 			</modules>
 		</profile>
 	</profiles>
@@ -275,22 +290,12 @@
 						<goals>
 							<goal>prepare-agent</goal>
 						</goals>
-						<configuration>
-							<skip>${coverage.skip}</skip>
-							<destFile>${sonar.jacoco.reportPath}</destFile>
-							<propertyName>failsafeArgline</propertyName>
-						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<groupId>org.sonarsource.scanner.maven</groupId>
-					<artifactId>sonar-maven-plugin</artifactId>
-					<version>${sonar-version}</version>
-				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>target-platform-configuration</artifactId>


### PR DESCRIPTION
- Allow to launch tests based on profiles
- Split test aggregator into ju and rcptt test aggregators
- Update Jenkins launch config

Change-Id: I34720306315d671fe042b7ee701507ffd8ce00fa
Signed-off-by: Arnaud Dieumegard <arnaud.dieumegard@obeo.fr>